### PR TITLE
Tlc376 page titles

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -29,15 +29,19 @@ to modify some of the meta-data for the site, this is the place to do it.
       {% assign page_title = title | append : ' | 18F ' %}
     {% endif %}
 
+    {% if description %}
+      {% assign page_description = description %}
+    {% endif %}
+
     <title>{{page_title}}{{ titles_roots[guide].title }} </title>
   <meta property="og:title" content="{{page_title}}" />
-  <meta name="description" content="{{page.description}}" />
-  <meta property="og:description" content="{{page.description}}" />
+  <meta name="description" content="{{page_description}}" />
+  <meta property="og:description" content="{{page_description}}" />
 
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@{{site.twitter}}" />
   <meta name="twitter:title" content="{{title}}" />
-  <meta name="twitter:description" content="{{page.description}}" />
+  <meta name="twitter:description" content="{{page_description}}" />
 
   <meta property="og:type" content="article" />
   <link rel="canonical" href="{{ page.url }}" />

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -29,19 +29,15 @@ to modify some of the meta-data for the site, this is the place to do it.
       {% assign page_title = title | append : ' | 18F ' %}
     {% endif %}
 
-    {% if description %}
-      {% assign page_description = description %}
-    {% endif %}
-
     <title>{{page_title}}{{ titles_roots[guide].title }} </title>
   <meta property="og:title" content="{{page_title}}{{ titles_roots[guide].title }}" />
-  <meta name="description" content="{{page_description}}" />
-  <meta property="og:description" content="{{page_description}}" />
+  <meta name="description" content="{{description}}" />
+  <meta property="og:description" content="{{description}}" />
 
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@{{site.twitter}}" />
   <meta name="twitter:title" content="{{title}}" />
-  <meta name="twitter:description" content="{{page_description}}" />
+  <meta name="twitter:description" content="{{description}}" />
 
   <meta property="og:type" content="article" />
   <link rel="canonical" href="{{ page.url }}" />

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -22,12 +22,15 @@ to modify some of the meta-data for the site, this is the place to do it.
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- Title and meta description
     ================================================== -->
-    {% if title %}
-    {% assign page_title = title | append : ' | ' %}
+
+    {% if seo_title %}
+      {% assign page_title = seo_title | append : ' | 18F ' %}
+    {% else %}
+      {% assign page_title = title | append : ' | 18F ' %}
     {% endif %}
 
-    <title> {{page_title}}{{ titles_roots[guide].title }} </title>
-  <meta property="og:title" content="{{page.title}}" />
+    <title>{{page_title}}{{ titles_roots[guide].title }} </title>
+  <meta property="og:title" content="{{page_title}}" />
   <meta name="description" content="{{page.description}}" />
   <meta property="og:description" content="{{page.description}}" />
 

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -34,7 +34,7 @@ to modify some of the meta-data for the site, this is the place to do it.
     {% endif %}
 
     <title>{{page_title}}{{ titles_roots[guide].title }} </title>
-  <meta property="og:title" content="{{page_title}}" />
+  <meta property="og:title" content="{{page_title}}{{ titles_roots[guide].title }}" />
   <meta name="description" content="{{page_description}}" />
   <meta property="og:description" content="{{page_description}}" />
 

--- a/content/derisking/state-field-guide/3-budgeting-tech.md
+++ b/content/derisking/state-field-guide/3-budgeting-tech.md
@@ -1,5 +1,6 @@
 ---
 title: Budgeting and overseeing tech projects
+seo_title: Budgeting and overseeing state-level tech projects
 tags: derisking
 permalink: /derisking/state-field-guide/budgeting-tech/
 layout: layouts/page

--- a/docs/replatforming.md
+++ b/docs/replatforming.md
@@ -24,6 +24,7 @@ agile:
   title: Agile
   root: /agile/
 ```
+
 ## Guide primary navigation
 
 The `_data/navigation.yaml` file is used to define the primary navigation for each guide. The guide’s tag is used as a key which maps to its list of link names and urls.
@@ -79,6 +80,13 @@ Use `sticky_sidenav: true` to stick the sidenav to the top of the window when sc
 
 ### Subnavs
 You can use the existing `subnav:` options in the original file's front matter to generate a subnav with the current page's anchor links. To prevent errors in `eleventyNavigation`, ensure the `parent` and `key` values are different.
+
+## Page titles
+By default, the page's `<title>` tag will use the `title` set in the page's front matter. 
+
+You can also set a custom page title using `seo_title` in the front matter, to improve the experience for people skimming search results. Reasons to write a custom page title include:
+- The `title` is more than 30-35 characters long
+- The `title` is too similar to titles on other guides. (Examples are "Introduction" or "Planning.")
 
 ## Ignoring assetPaths
 We want to avoid commiting the `assetPaths.json` file, but need to keep it out of the project `.gitignore` in order to allow eleventy to rebuild when it is changed. One way to resolve this issue is to add `assetPaths.json` to the git exclude list:


### PR DESCRIPTION
To address [TLC issue 376](https://github.com/18F/TLC-crew/issues/376)

## Changes proposed in this pull request:
- Add `seo_title` as available front matter option, if the page's `title` is too long or does not give enough context for a sub-60-char `<title>` tag. [See example.](https://federalist-864a0936-e148-4df8-8602-6b0992887566.sites.pages.cloud.gov/preview/18f/approaches/tlc376-page-titles/derisking/state-field-guide/budgeting-tech/)
- Convert Jekyll page descriptions to Eleventy-readable page descriptions. [See example.](https://federalist-864a0936-e148-4df8-8602-6b0992887566.sites.pages.cloud.gov/preview/18f/approaches/tlc376-page-titles/ux-guide/our-approach/values-and-principles/) (Although also note that only pages in the UX Guide have `description` set in front matter.)

