### PR TITLE
Clarify who reviews content changes.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,37 @@
+# This file defines what approvals are needed to update both code and content.
+#
+# GitHub will automatically tag these people for review when anyone opens a pull request,
+# so no need to use this file directly unless you are updating it.
+# 
+# The 18F Chief of Delivery, as Product Owner, is ultimately accountable for keeping
+# this list up-to-date. If you spot anything outdated or are handing off your responsibility, 
+# feel free to make changes to this file and open a pull request, file an issue on GitHub,
+# or notify the Chief of Delivery. 
+# 
+# There are no additional approvals needed outside of those listed in this document. Of
+# course, feel free to request a review of your changes from anyone who you would like,
+# given the content of the changes you are making.
+
+# Unless another rule applies below, request review from someone on the TLC crew 
+# or the Chief of Delivery.
+* @18F/18f-tlc-crew @adunkman
+
+# Guides are currently organized by general topic area, and content approvals are 
+# delegated to relevant subject matter experts.
+
+/content/accessibility/**/*.md   @jasnakai
+/content/agile/**/*.md           @adunkman
+/content/brand/**/*.md           @igorkorenfeld
+/content/content-guide/**/*.md   @michelle-rago
+/content/derisking/**/*.md       @adunkman
+/content/design/**/*.md          @MelissaBraxton
+/content/eng-hiring/**/*.md      @amymok
+/content/engineering/**/*.md     @amymok
+/content/product/**/*.md         @allisonnorman
+/content/ux-guide/**/*.md        @juliaklindpaintner
+
+# The pull request template and CODEOWNERS files should be reviewed by the Chief of Delivery;
+# placed at the end of the file to ensure they are not overridden by another rule.
+/.github/pull_request_template.md @adunkman
+/.github/CODEOWNERS @adunkman
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A work in progress repository for consolidating the 18F Guides and Methods
 
 ## How do I update this content?
 
-The [CODEOWNERS file](.github/CODEOWNERS) keeps track of who is in review & approver roles for content in this repository — if you’re not receiving a timely review or notice the list is outdated, reach out to 18F’s Chief of Delivery for assistance. These reviewers will be automatically tagged appropriately when opening pull requests. 
+The [CODEOWNERS file](.github/CODEOWNERS) keeps track of who is in review & approver roles for content in this repository — if you’re not receiving a timely (within two weeks) review or notice the list is outdated, reach out to 18F’s Chief of Delivery for assistance. These reviewers will be automatically tagged appropriately when opening pull requests. 
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A work in progress repository for consolidating the 18F Guides and Methods
 
+## How do I update this content?
+
+The [CODEOWNERS file](.github/CODEOWNERS) keeps track of who is in review & approver roles for content in this repository — if you’re not receiving a timely review or notice the list is outdated, reach out to 18F’s Chief of Delivery for assistance. These reviewers will be automatically tagged appropriately when opening pull requests. 
+
 ## Development
 
 ### Docker


### PR DESCRIPTION
A challenge which we need to solve when consolidating our Guides & Methods is clearly communicating who is responsible for reviewing and approving pull requests, so that the content remains useful and updated. This PR takes a step in that direction. I expect we will need to revisit this plan shortly. 

This is part of the `next` phase of the [Roadmap update in July](https://docs.google.com/presentation/d/1BRkxeic_39_oK-zQYmbfXpCrJuR_MZaZnFmnQS7WSoE/edit#slide=id.g5ecdbbee9e_0_0) — and following up on recommendations made in [#374](https://github.com/18F/TLC-crew/issues/374).

I reached out to those below, to set these expectations: 

> **What I’m asking of you**
>As a part of the broader effort, and in efforts to maintain and update content, the TLC crew will be proposing changes to the combined guides. Some of those changes will be revising content that subject matter experts should be reviewing, and I’m asking you to be one of those subject matter experts.
>
>Today, that will closely mimic the structure of our previous guides & methods. As we adapt to what is learned through researching a unified information architecture, we’ll need to adapt how we involve subject matter experts so it is clear who will review and approve changes. 
>
>If you say yes, I’ll mark you to automatically be tagged for reviewing GitHub pull requests for content changes.
>
> **What to consider when reviewing**
>I’m asking you to consider that the guides are specific to 18F and its practices — that is, the ones we actively use and recommend on our projects. If you have questions or concerns, feel free to tag me (or others) in for review — you needn’t be the only authority on this, but because of your expertise you are likely a good candidate for review, and would know who else to involve if needed. 
>
>I ask you to opt for action over inaction, and to ask for help when needed. If you are comfortable with the change, you are the authority — you can merge as you deem appropriate. I’ve already spoken with the other members of the 18F leadership team, and they are supportive of you in this role. 


## Changes proposed in this pull request:

- Establishes a CODEOWNERS file to auto-tag pull request reviewers
- Adds a note to the README to point people to CODEOWNERS

## Security considerations

No new considerations — changes are to documentation and GitHub process flow. Security considerations relate to these contributor’s push access to this repository, which is an existing consideration and has internal controls associated with it. 
